### PR TITLE
feat: Graceful shutdown upon signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Example implementations of common requirements for website serving applications.
 
 1. Basic HTTP server - https://github.com/karlskewes/go-yahs/pull/1
 1. GitHub Action CI to lint & test - https://github.com/karlskewes/go-yahs/pull/2
+1. Graceful shutdown - https://github.com/karlskewes/go-yahs/pull/4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/karlskewes/go-yahs
 
 go 1.20
+
+require golang.org/x/sync v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,20 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	httpShutdownPreStopDelaySeconds = 1
+	httpShutdownTimeoutSeconds      = 1
 )
 
 func main() {
@@ -10,9 +22,47 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", http.NotFoundHandler())
+	srv := &http.Server{
+		Addr:    "localhost:8080",
+		Handler: mux,
+	}
 
-	err := http.ListenAndServe(":8080", mux)
-	if err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	var group errgroup.Group
+
+	group.Go(func() error {
+		<-ctx.Done()
+
+		log.Print("received OS signal to shutdown, use Ctrl+C again to force")
+
+		// reset signals so ctrl+c can be captured again
+		stop()
+
+		// before shutting down the HTTP server wait for any HTTP requests that are
+		// in transit on the network. Common in Kubernetes and other distributed
+		// systems.
+		time.Sleep(httpShutdownPreStopDelaySeconds * time.Second)
+
+		// give active connections time to complete or disconnect before closing.
+		ctx2, cancel := context.WithTimeout(ctx, httpShutdownTimeoutSeconds*time.Second)
+		defer cancel()
+
+		return srv.Shutdown(ctx2)
+	})
+
+	group.Go(func() error {
+		err := srv.ListenAndServe()
+		// http.ErrServerClosed is expected at shutdown.
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+
+		return err
+	})
+
+	if err := group.Wait(); err != nil {
 		log.Print(err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,44 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestMain(t *testing.T) {
 	go main()
 
-	resp, err := http.Get("http://localhost:8080")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:8080", nil)
 	if err != nil {
-		t.Errorf("failed to create GET request: %v", err)
+		t.Fatalf("failed to create a new request: %v", err)
+	}
+
+	// HTTP server `go main()` goroutine might not be scheduled yet.
+	// Attempt GET request a few times with a delay between each request.
+	client := &http.Client{}
+	var resp *http.Response
+	var doErr error
+
+	for i := 0; i < 3; i++ {
+		resp, doErr = client.Do(req)
+		if doErr == nil {
+			defer resp.Body.Close()
+
+			break
+		}
+
+		// wait for server to startup
+		time.Sleep(time.Duration(i) * time.Second)
+	}
+
+	if doErr != nil {
+		t.Fatalf("failed to query HTTP server")
 	}
 
 	want := http.StatusNotFound
-	if resp != nil && resp.StatusCode != want {
+	if resp.StatusCode != want {
 		t.Errorf("want: %d - got: %d", want, resp.StatusCode)
 	}
 }


### PR DESCRIPTION
Gracefully shutdown the application upon receiving a signal.
This could be "ctrl+c" on the command line or a signal from an orchestration system like systemd, container runtimes, etc.

This requires running the HTTP server in it's own goroutine which slightly complicates testing.

The grace periods for handling in-transit HTTP requests and active connections are both hard coded as constants for now.