### PR TITLE
feat: Use a Run() function for application logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Example implementations of common requirements for website serving applications.
 1. Basic HTTP server - https://github.com/karlskewes/go-yahs/pull/1
 1. GitHub Action CI to lint & test - https://github.com/karlskewes/go-yahs/pull/2
 1. Graceful shutdown - https://github.com/karlskewes/go-yahs/pull/4
+1. Testable application invocations. Split `main()` with `Run()` - https://github.com/karlskewes/go-yahs/pull/5

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-func TestMain(t *testing.T) {
-	go main()
+func TestRun(t *testing.T) {
+	go Run(context.Background())
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:8080", nil)
 	if err != nil {


### PR DESCRIPTION
It is difficult to test `main()` functions with different flag arguments and input/output (STDIN, STDOUT, STDERR).

Split http server logic to a `Run()` function without any other changes in preparation for future work.