### PR TITLE
feat: Enable third party app use of http server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Run go build
-        run: go build ./main.go
+        run: go build ./cmd/server/main.go
 
       - name: Staticcheck
         uses: dominikh/staticcheck-action@v1.3.0

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Example implementations of common requirements for website serving applications.
 1. GitHub Action CI to lint & test - https://github.com/karlskewes/go-yahs/pull/2
 1. Graceful shutdown - https://github.com/karlskewes/go-yahs/pull/4
 1. Testable application invocations. Split `main()` with `Run()` - https://github.com/karlskewes/go-yahs/pull/5
+1. Enable importing into other applications, move `package main` to `cmd/..` - https://github.com/karlskewes/go-yahs/pull/6

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	httpserver "github.com/karlskewes/go-yahs"
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	log.Print("go-yahs starting")
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	var group errgroup.Group
+	group.Go(func() error {
+		<-ctx.Done()
+
+		log.Print("received OS signal to shutdown, use Ctrl+C again to force")
+
+		// reset signals so a second ctrl+c will terminate the application.
+		stop()
+
+		return nil
+	})
+
+	group.Go(func() error {
+		return httpserver.Run(ctx)
+	})
+
+	if err := group.Wait(); err != nil {
+		log.Print(err)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -1,12 +1,9 @@
-package main
+package httpserver
 
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -16,34 +13,6 @@ const (
 	httpShutdownPreStopDelaySeconds = 1
 	httpShutdownTimeoutSeconds      = 1
 )
-
-func main() {
-	log.Print("go-yahs starting")
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	var group errgroup.Group
-
-	group.Go(func() error {
-		<-ctx.Done()
-
-		log.Print("received OS signal to shutdown, use Ctrl+C again to force")
-
-		// reset signals so a second ctrl+c will terminate the application.
-		stop()
-
-		return nil
-	})
-
-	group.Go(func() error {
-		return Run(ctx)
-	})
-
-	if err := group.Wait(); err != nil {
-		log.Print(err)
-	}
-}
 
 // Run starts an HTTP server and gracefully shuts down when the provided
 // context is marked done.

--- a/server_test.go
+++ b/server_test.go
@@ -1,4 +1,4 @@
-package main
+package httpserver
 
 import (
 	"context"


### PR DESCRIPTION
Migrating the entry point `package main` to `cmd` enables using the http server package in other applications.