### PR TITLE
feat: Create an App type to hold config & state

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Example implementations of common requirements for website serving applications.
 1. Graceful shutdown - https://github.com/karlskewes/go-yahs/pull/4
 1. Testable application invocations. Split `main()` with `Run()` - https://github.com/karlskewes/go-yahs/pull/5
 1. Enable importing into other applications, move `package main` to `cmd/..` - https://github.com/karlskewes/go-yahs/pull/6
+1. Create an `App` type to hold config & state - https://github.com/karlskewes/go-yahs/pull/7

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,8 @@ import (
 func main() {
 	log.Print("go-yahs starting")
 
+	app := httpserver.NewApp()
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -29,7 +31,7 @@ func main() {
 	})
 
 	group.Go(func() error {
-		return httpserver.Run(ctx)
+		return app.Run(ctx)
 	})
 
 	if err := group.Wait(); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	go Run(context.Background())
+	app := NewApp()
+	//nolint:errcheck // If app fails to run then the test will fail.
+	go app.Run(context.Background())
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:8080", nil)
 	if err != nil {


### PR DESCRIPTION
Extending the `App` type enables supporting custom configuration such as `http.Server`, routes, timeouts, etc.