### PR TITLE
chore: Rename to yahs for simpler imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-yahs
+# yahs
 
 Yet another HTTP server.
 
@@ -6,10 +6,11 @@ Example implementations of common requirements for website serving applications.
 
 ## Requirements
 
-1. Basic HTTP server - https://github.com/karlskewes/go-yahs/pull/1
-1. GitHub Action CI to lint & test - https://github.com/karlskewes/go-yahs/pull/2
-1. Graceful shutdown - https://github.com/karlskewes/go-yahs/pull/4
-1. Testable application invocations. Split `main()` with `Run()` - https://github.com/karlskewes/go-yahs/pull/5
-1. Enable importing into other applications, move `package main` to `cmd/..` - https://github.com/karlskewes/go-yahs/pull/6
-1. Create an `App` type to hold config & state - https://github.com/karlskewes/go-yahs/pull/7
-1. Functional Options pattern for config, support custom `http.Server{}` - https://github.com/karlskewes/go-yahs/pull/8
+1. Basic HTTP server - https://github.com/karlskewes/yahs/pull/1
+1. GitHub Action CI to lint & test - https://github.com/karlskewes/yahs/pull/2
+1. Graceful shutdown - https://github.com/karlskewes/yahs/pull/4
+1. Testable application invocations. Split `main()` with `Run()` - https://github.com/karlskewes/yahs/pull/5
+1. Enable importing into other applications, move `package main` to `cmd/..` - https://github.com/karlskewes/yahs/pull/6
+1. Create an `App` type to hold config & state - https://github.com/karlskewes/yahs/pull/7
+1. Functional Options pattern for config, support custom `http.Server{}` - https://github.com/karlskewes/yahs/pull/8
+1. Rename package to `yahs` for simpler imports - https://github.com/karlskewes/yahs/pull/9

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,14 +6,14 @@ import (
 	"os/signal"
 	"syscall"
 
-	httpserver "github.com/karlskewes/go-yahs"
+	"github.com/karlskewes/yahs"
 	"golang.org/x/sync/errgroup"
 )
 
 func main() {
-	log.Print("go-yahs starting")
+	log.Print("yahs starting")
 
-	app, err := httpserver.NewApp()
+	app, err := yahs.NewApp()
 	if err != nil {
 		log.Fatalf("failed to create new app: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/karlskewes/go-yahs
+module github.com/karlskewes/yahs
 
 go 1.20
 

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package httpserver
+package yahs
 
 import (
 	"context"

--- a/server_test.go
+++ b/server_test.go
@@ -1,4 +1,4 @@
-package httpserver
+package yahs
 
 import (
 	"context"


### PR DESCRIPTION
Go variables can't contain hyphens so it would be simpler for consumers to import and use directly rather than having to name the import.

With this change we get:

```golang
import "github.com/karlskewes/yahs"

func main() {
  app, _ := yahs.NewApp()
}
```

Instead of:

```golang
import httpserver "github.com/karlskewes/go-yahs"

func main() {
  app, _ := httpserver.NewApp()
}
```