### PR TITLE
feat: HTTP Route precedence support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Example implementations of common requirements for website serving applications.
 1. Rename HTTP Server from App to Server - https://github.com/karlskewes/yahs/pull/10
 1. Custom Route handling - https://github.com/karlskewes/yahs/pull/11
 1. Embedded filesystem for assets and HTML templates - https://github.com/karlskewes/yahs/pull/12
+1. HTTP Route precedence - https://github.com/karlskewes/yahs/pull/13

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -72,7 +72,7 @@ func NewApp(hs *yahs.Server, logger *slog.Logger) *App {
 }
 
 func (ws *App) addRoutes() {
-	ws.hs.AddRoute("GET", "/", ws.Home)
+	ws.hs.AddRoute(yahs.NewRoute("GET", "/", ws.Home))
 }
 
 func (ws *App) Home(w http.ResponseWriter, r *http.Request) {

--- a/embeddedfs_test.go
+++ b/embeddedfs_test.go
@@ -80,7 +80,7 @@ func TestHandleTemplates(t *testing.T) {
 			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			w := httptest.NewRecorder()
-			hs.handleTemplates().ServeHTTP(w, req)
+			hs.HandleTemplates().ServeHTTP(w, req)
 			res := w.Result()
 			defer res.Body.Close()
 			if tc.statusCode != res.StatusCode {
@@ -97,13 +97,9 @@ func BenchmarkHandleTemplates(b *testing.B) {
 		b.Fatalf("failed to create http server: %v", err)
 	}
 
-	// TODO
-	// b.Cleanup(func() { _ = s.Shutdown() })
-	b.Logf("b.N is %d", b.N)
-
 	for i := 0; i < b.N; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
 		w := httptest.NewRecorder()
-		hs.handleTemplates().ServeHTTP(w, req)
+		hs.HandleTemplates().ServeHTTP(w, req)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -63,7 +63,8 @@ func TestAddRoute(t *testing.T) {
 	pattern := "/path/to/endpoint"
 	handler := http.NotFoundHandler().ServeHTTP
 
-	hs.AddRoute(method, pattern, handler)
+	route := NewRoute(method, pattern, handler)
+	hs.AddRoute(route)
 
 	if len(hs.routes) != 1 {
 		t.Errorf("unexpected number of routes, want: %d - got: %d", 1, len(hs.routes))
@@ -75,6 +76,35 @@ func TestAddRoute(t *testing.T) {
 
 	if hs.routes[0].pattern.String() != "^"+pattern+"$" {
 		t.Errorf("unexpected regex pattern, want: %s - got: %s", pattern, hs.routes[0].pattern.String())
+	}
+}
+
+func TestSetRoute(t *testing.T) {
+	t.Parallel()
+
+	hs, err := New()
+	if err != nil {
+		t.Errorf("failed to create new http server: %v", err)
+	}
+
+	method := "GET"
+	pattern := "/path/to/endpoint"
+	handler := http.NotFoundHandler().ServeHTTP
+
+	route1 := NewRoute(method, pattern+"1", handler)
+	route2 := NewRoute(method, pattern+"2", handler)
+	hs.SetRoutes([]Route{route1, route2})
+
+	if len(hs.routes) != 2 {
+		t.Errorf("unexpected number of routes, want: %d - got: %d", 2, len(hs.routes))
+	}
+
+	if hs.routes[0].pattern.String() != "^"+pattern+"1$" {
+		t.Errorf("unexpected regex pattern, want: %s - got: %s", pattern+"1", hs.routes[0].pattern.String())
+	}
+
+	if hs.routes[1].pattern.String() != "^"+pattern+"2$" {
+		t.Errorf("unexpected regex pattern, want: %s - got: %s", pattern+"2", hs.routes[1].pattern.String())
 	}
 }
 
@@ -113,7 +143,9 @@ func TestServe_CustomRoute(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	}
 
-	hs.AddRoute(method, pattern, handler)
+	hs.AddRoute(
+		NewRoute(method, pattern, handler),
+	)
 
 	ts := httptest.NewServer(hs.srv.Handler)
 


### PR DESCRIPTION
When an `Embeddedfs` for static files and templates is configured, default HTTP routes are added that match all incoming requests. This makes any subsequent custom route additions ineffective.

This commit:
- Exposes `Route` type and adds the `NewRoute()` function to create a `Route`.
- Adds a `SetRoutes()` method to declaratively define all routes, first match wins.
- Exposes static file and template HTTP handler methods so that they can be used by consumers in `NewRoute()` function calls, enabling serving on any custom regex pattern instead of just the defaults.