### PR TITLE
fix: Exit if unable to listen on address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Example implementations of common requirements for website serving applications.
 1. Custom Route handling - https://github.com/karlskewes/yahs/pull/11
 1. Embedded filesystem for assets and HTML templates - https://github.com/karlskewes/yahs/pull/12
 1. HTTP Route precedence - https://github.com/karlskewes/yahs/pull/13
+1. Exit if unable to listen on address - https://github.com/karlskewes/yahs/pull/15

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"html/template"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -158,6 +159,11 @@ func (hs *Server) Serve(w http.ResponseWriter, r *http.Request) {
 // Run starts the HTTP Server application and gracefully shuts down when the
 // provided context is marked done.
 func (hs *Server) Run(ctx context.Context) error {
+	ln, err := net.Listen("tcp", hs.srv.Addr)
+	if err != nil {
+		return err
+	}
+
 	var group errgroup.Group
 
 	group.Go(func() error {
@@ -176,7 +182,7 @@ func (hs *Server) Run(ctx context.Context) error {
 	})
 
 	group.Go(func() error {
-		err := hs.srv.ListenAndServe()
+		err := hs.srv.Serve(ln)
 		// http.ErrServerClosed is expected at shutdown.
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil


### PR DESCRIPTION
Exit immediately if unable to listen on the server's address. Previously service would start and only surface the bind error upon SIGTERM or similar signal.